### PR TITLE
fix: add latest tag to command in og image

### DIFF
--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -151,7 +151,7 @@ export default async function Image() {
                 letterSpacing: '-0.01em',
               }}
             >
-              npx create-solana-dapp
+              npx create-solana-dapp@latest
             </span>
           </div>
         </div>


### PR DESCRIPTION
Any user facing place where the invocation of `create-solana-dapp` is present, we need to make sure to add the `@latest` tag in order to make sure people do this, in order to guarantee proper behavior of the CLI.

This is in line with other famous CLI's like:

- [create-next-app](https://nextjs.org/docs/app/api-reference/cli/create-next-app) 
- [create-vite](https://vite.dev/guide/#scaffolding-your-first-vite-project)
- [shadcn](https://ui.shadcn.com/docs/installation/next)

All these CLI's consistently add the tag to prevent cache from breaking the usage. We should follow this example when suggesting how to run `create-solana-dapp`.