### PR TITLE
Fix: Default to npm and correct template page titles

### DIFF
--- a/src/app/developers/templates/[source]/[name]/page.tsx
+++ b/src/app/developers/templates/[source]/[name]/page.tsx
@@ -10,7 +10,7 @@ export async function generateMetadata({
   const { name, source } = await params
 
   const template = templates.find(
-    (t) => t.id === name && t.source.id === source
+    (t) => t.name === name && t.source.id === source
   )
 
   if (!template) {

--- a/src/components/templates/templates-ui-generate-command.tsx
+++ b/src/components/templates/templates-ui-generate-command.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { CheckIcon, CopyIcon } from 'lucide-react'
 
-const pms = ['bun', 'npm', 'pnpm', 'yarn']
+const pms = ['npm', 'pnpm', 'yarn', 'bun']
 
 function getCommand(pm: string, template: string) {
   switch (pm) {
@@ -21,7 +21,7 @@ function getCommand(pm: string, template: string) {
 }
 
 export function TemplatesUiGenerateCommand({ template: { source, path } }: { template: RepokitTemplate }) {
-  const [selected, setSelected] = useState('pnpm')
+  const [selected, setSelected] = useState('npm')
   const [isCopied, setIsCopied] = useState(false)
   const template = `${source.owner}/${source.repo}/${path}`
   const command = getCommand(selected, template)


### PR DESCRIPTION
## Summary
- Switched the default package manager from pnpm to npm in the generate dialog
- Fixed template pages showing "Template Not Found" in the title

## Changes

### 1. Generate Dialog (`templates-ui-generate-command.tsx`)
- npm is now the first option and default selection instead of pnpm
- Reordered package managers list to: npm, pnpm, yarn, bun

### 2. Template Metadata (`[source]/[name]/page.tsx`)
- Fixed template lookup in `generateMetadata` function
- Changed from comparing `t.id` (full path) to `t.name` (template name)
- This fixes the bug where all template pages showed "Template Not Found" in the browser title

## Note
The template readme content is generated and should be updated at the source. This PR only updates the UI components.

## Test Plan
- [ ] Verify generate dialog shows npm as default
- [ ] Test copying commands from the UI
- [ ] Ensure pnpm, yarn, and bun options still work when selected
- [ ] Verify template pages show correct titles (e.g., "gill-next-tailwind-counter - Solana Template")
- [ ] Check browser tab titles are correct for template pages